### PR TITLE
Add go mod, updates installation guide

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/rwxsu/goot
+
+go 1.12


### PR DESCRIPTION
Creating a `go.mod` file allows people to just clone and build:

```
git clone ...
cd goot
go build / go run main.go
```

So with a `go.mod` file you can get out of the `GOPATH` stuff :)