### PR TITLE
filepath.Glob only returns syntax errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,10 +12,8 @@ import (
 func main() {
 	m := make(game.Map)
 
-	filenames, err := filepath.Glob("data/map/sectors/*")
-	if err != nil {
-		panic(err)
-	}
+	const sectors = "data/map/sectors/*"
+	filenames, _ := filepath.Glob(sectors)
 	for _, fn := range filenames {
 		m.LoadSector(fn)
 	}
@@ -49,8 +47,8 @@ func main() {
 		},
 		Skull: 3,
 		Icons: 1,
-		Light: game.Light{0x7, 0xd7},
-		World: game.World{Light: game.Light{0x00, 0xd7}},
+		Light: game.Light{Level: 0x7, Color: 0xd7},
+		World: game.World{Light: game.Light{Level: 0x00, Color: 0xd7}},
 		Speed: 70,
 	}
 


### PR DESCRIPTION
since the glob pattern is static, there is no point is catching this error.
ref: https://golang.org/pkg/path/filepath/#Glob
the other is change is due go vet complaining:
> ./main.go:52:10: github.com/rwxsu/goot/game.Light composite literal uses unkeyed fields
