### PR TITLE
Use just net.Conn, the pointer is redundant

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 	}
 
 	for {
-		func(c *net.Conn) {
+		func(c net.Conn) {
 			req := network.RecvMessage(c)
 			if req == nil {
 				return
@@ -98,12 +98,12 @@ func main() {
 				network.ParseCommand(c, req, &player, &m, code)
 				return
 			}
-			(*c).Close()
-			(*c), err = l.Accept()
+			c.Close()
+			c, err = l.Accept()
 			if err != nil {
 				log.Println(err)
 				return
 			}
-		}(&c)
+		}(c)
 	}
 }

--- a/network/network.go
+++ b/network/network.go
@@ -8,14 +8,14 @@ const debug = true
 
 // RecvMessage reads the incoming message length (first two bytes), followed by
 // how many bytes the incoming message length is.
-func RecvMessage(c *net.Conn) *Message {
+func RecvMessage(c net.Conn) *Message {
 	msg := NewMessage()
-	(*c).Read(msg.Buffer[0:2]) // incoming message length
+	c.Read(msg.Buffer[0:2]) // incoming message length
 	if msg.Length() == 0 {
 		return nil
 	}
 	bytes := make([]uint8, msg.Length())
-	(*c).Read(bytes)
+	c.Read(bytes)
 	msg.Buffer = append(msg.Buffer, bytes...)
 	if debug {
 		msg.HexDump("recv")
@@ -24,8 +24,8 @@ func RecvMessage(c *net.Conn) *Message {
 }
 
 // SendMessage sends a message to the given connection.
-func SendMessage(dest *net.Conn, msg *Message) {
-	(*dest).Write(msg.Buffer)
+func SendMessage(dest net.Conn, msg *Message) {
+	dest.Write(msg.Buffer)
 	if debug {
 		msg.HexDump("send")
 	}

--- a/network/protocol.go
+++ b/network/protocol.go
@@ -13,7 +13,7 @@ const (
 	PlayerMessageTypeCancel uint8 = 0x17
 )
 
-func ParseCommand(c *net.Conn, msg *Message, player *game.Creature, m *game.Map, code uint8) {
+func ParseCommand(c net.Conn, msg *Message, player *game.Creature, m *game.Map, code uint8) {
 	switch code {
 	case 0x65:
 		if !SendMoveCreature(c, player, m, game.North, code) {
@@ -46,14 +46,14 @@ func ParseCommand(c *net.Conn, msg *Message, player *game.Creature, m *game.Map,
 	}
 }
 
-func SendInvalidClientVersion(c *net.Conn) {
+func SendInvalidClientVersion(c net.Conn) {
 	msg := NewMessage()
 	msg.WriteUint8(0x0a)
 	msg.WriteString("Only protocol 7.40 allowed!")
 	SendMessage(c, msg)
 }
 
-func SendCharacterList(c *net.Conn) {
+func SendCharacterList(c net.Conn) {
 	characters := make([]game.Creature, 2)
 	characters[0].Name = "admin"
 	characters[0].World.Name = "test"
@@ -79,7 +79,7 @@ func SendCharacterList(c *net.Conn) {
 	SendMessage(c, res)
 }
 
-func SendSnapback(c *net.Conn, player *game.Creature) {
+func SendSnapback(c net.Conn, player *game.Creature) {
 	msg := NewMessage()
 	msg.WriteUint8(0xb5)
 	msg.WriteUint8(player.Direction)
@@ -87,13 +87,13 @@ func SendSnapback(c *net.Conn, player *game.Creature) {
 	SendCancelMessage(c, "Sorry, not possible.")
 }
 
-func SendCancelMessage(c *net.Conn, str string) {
+func SendCancelMessage(c net.Conn, str string) {
 	msg := NewMessage()
 	AddPlayerMessage(msg, str, PlayerMessageTypeCancel)
 	SendMessage(c, msg)
 }
 
-func SendMoveCreature(c *net.Conn, player *game.Creature, m *game.Map, direction, code uint8) bool {
+func SendMoveCreature(c net.Conn, player *game.Creature, m *game.Map, direction, code uint8) bool {
 	var width, height uint16
 	from := player.Position
 	to := player.Position
@@ -137,7 +137,7 @@ func SendMoveCreature(c *net.Conn, player *game.Creature, m *game.Map, direction
 	return true
 }
 
-func SendAddCreature(c *net.Conn, character *game.Creature, m *game.Map) {
+func SendAddCreature(c net.Conn, character *game.Creature, m *game.Map) {
 	res := NewMessage()
 	res.WriteUint8(0x0a)
 	res.WriteUint32(character.ID) // ID


### PR DESCRIPTION
since net.TCPListener methods are implementing net.Conn through a pointer receiver, there is no need to pointer here, it's just causing dereference noise, fixes #2.